### PR TITLE
TIG-1956: Fix cors swagger issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'flask==1.0.4',
+        'flask==1.1.1',
         'flask-restplus==0.13.0',
     ],
     entry_points={

--- a/src/selectedtests/app/app.py
+++ b/src/selectedtests/app/app.py
@@ -4,6 +4,7 @@ Application to serve API of selected-tests service.
 
 from flask import Flask
 from flask_restplus import Api
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from selectedtests.app.controllers.health_controller import add_health_endpoints
 
@@ -17,6 +18,7 @@ def create_app() -> Flask:
     :return: Instance of flask application.
     """
     app = Flask(__name__)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
     api = Api(
         app,
         version="1.0",

--- a/tests/selectedtests/app/test_app.py
+++ b/tests/selectedtests/app/test_app.py
@@ -1,0 +1,17 @@
+from flask import testing
+
+
+def test_swagger_endpoint(app_client: testing.FlaskClient):
+    """
+    Test /health endpoint
+    """
+    response = app_client.get("/swagger")
+    assert response.status_code == 200
+
+
+def test_swagger_json_endpoint(app_client: testing.FlaskClient):
+    """
+    Test /health endpoint
+    """
+    response = app_client.get("/swagger.json")
+    assert response.status_code == 200


### PR DESCRIPTION
The swagger UI is not being served due to a cors issue. Looks to be the issue found here:
https://github.com/noirbizarre/flask-restplus/issues/701

This pr has the code in the link that should fix it.