### PR TITLE
Fixed test_health_controller data comparison.

### DIFF
--- a/tests/selectedtests/app/controllers/test_health_controller.py
+++ b/tests/selectedtests/app/controllers/test_health_controller.py
@@ -7,4 +7,5 @@ def test_health_endpoint(app_client: testing.FlaskClient):
     """
     response = app_client.get("/health")
     assert response.status_code == 200
-    assert "online" and "true" in response.get_data(as_text=True)
+    res_data = response.get_data(as_text=True)
+    assert "online" in res_data and "true" in res_data


### PR DESCRIPTION
Python will interpret "assert "online" and "true" in response.get_data(as_text=True)" as "assert ("online") and ("true" in response.get_data(as_text=True))," which will always evaluate to true as long as "true" is in the response data, even if "online" is not in the response data. I just went ahead and stored the response data in a variable and check if "online" is in the res_data and if "true" is in the res_data.