### PR TITLE
Build variant regex should default to "!.*" if not passed into create…

### DIFF
--- a/src/selectedtests/task_mappings/cli.py
+++ b/src/selectedtests/task_mappings/cli.py
@@ -116,29 +116,22 @@ def create(
         else:
             module_file_regex = re.compile(module_source_file_regex)
 
+    build_regex = None
+    if build_variant_regex:
+       build_regex = re.compile(build_variant_regex)
+
     LOGGER.info(f"Creating task mappings for {evergreen_project}")
 
-    if build_variant_regex:
-        mappings = TaskMappings.create_task_mappings(
-            evg_api,
-            evergreen_project,
-            after_date,
-            before_date,
-            file_regex,
-            module_name,
-            module_file_regex,
-            re.compile(build_variant_regex),
-        )
-    else:
-        mappings = TaskMappings.create_task_mappings(
-            evg_api,
-            evergreen_project,
-            after_date,
-            before_date,
-            file_regex,
-            module_name,
-            module_file_regex,
-        )
+    mappings = TaskMappings.create_task_mappings(
+        evg_api,
+        evergreen_project,
+        after_date,
+        before_date,
+        file_regex,
+        module_name,
+        module_file_regex,
+        build_regex,
+    )
 
     transformed_mappings = mappings.transform()
 

--- a/src/selectedtests/task_mappings/cli.py
+++ b/src/selectedtests/task_mappings/cli.py
@@ -118,7 +118,7 @@ def create(
 
     build_regex = None
     if build_variant_regex:
-       build_regex = re.compile(build_variant_regex)
+        build_regex = re.compile(build_variant_regex)
 
     LOGGER.info(f"Creating task mappings for {evergreen_project}")
 

--- a/src/selectedtests/task_mappings/mappings.py
+++ b/src/selectedtests/task_mappings/mappings.py
@@ -42,7 +42,7 @@ class TaskMappings:
         file_regex: Pattern,
         module_name: str = None,
         module_file_regex: Pattern = None,
-        build_regex: Pattern = compile("!.*"),
+        build_regex: Pattern = None,
     ):
         """
         Create the task mappings for an evergreen project. Optionally looks at an associated module.
@@ -54,7 +54,7 @@ class TaskMappings:
         :param file_regex: Regex pattern to match changed files against.
         :param module_name: Name of the module associated with the evergreen project to also analyze
         :param module_file_regex: Regex pattern to match changed files of the module against.
-        :param build_regex: Regex pattern to match build variant names against. Defaults to "!.*"
+        :param build_regex: Regex pattern to match build variant names against. Defaults to None.
         :return: An instance of the task mappings class
         """
         log = LOGGER.bind(
@@ -271,6 +271,8 @@ def _filter_non_matching_distros(builds: List[Build], build_regex: Pattern) -> L
     :param build_regex: Regex to match the builds' display_names against
     :return: A list of the builds that are required.
     """
+    if not build_regex:
+        return builds
     return [build for build in builds if match(build_regex, build.display_name)]
 
 

--- a/src/selectedtests/task_mappings/mappings.py
+++ b/src/selectedtests/task_mappings/mappings.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor as Executor
 from datetime import datetime
 from typing import List, Dict, Set
 from tempfile import TemporaryDirectory
-from re import match, compile
+from re import match
 from typing import Pattern
 
 from evergreen.api import Version, Build, Task, EvergreenApi

--- a/tests/selectedtests/task_mappings/test_task_mappings.py
+++ b/tests/selectedtests/task_mappings/test_task_mappings.py
@@ -354,12 +354,21 @@ class TestFilterDistros:
         for distro in optional_distros:
             assert distro not in fitered_distros
 
+    def test_filter_all_distros(self):
+        optional_distros = [MagicMock(display_name=f"distro{i}") for i in range(10)]
+
+        filtered_distros = under_test._filter_non_matching_distros(
+            optional_distros, re.compile("#")
+        )
+
+        assert 0 == len(filtered_distros)
+        for distro in optional_distros:
+            assert distro not in filtered_distros
+
     def test_missing_build_regex_argument(self):
         distros = [MagicMock(display_name=f"distro{i}") for i in range(10)]
 
-        filtered_distros = under_test._filter_non_matching_distros(
-            distros, None
-        )
+        filtered_distros = under_test._filter_non_matching_distros(distros, None)
 
         assert len(distros) == len(filtered_distros)
 

--- a/tests/selectedtests/task_mappings/test_task_mappings.py
+++ b/tests/selectedtests/task_mappings/test_task_mappings.py
@@ -354,16 +354,14 @@ class TestFilterDistros:
         for distro in optional_distros:
             assert distro not in fitered_distros
 
-    def test_filter_all_distros(self):
-        optional_distros = [MagicMock(display_name=f"distro{i}") for i in range(10)]
+    def test_missing_build_regex_argument(self):
+        distros = [MagicMock(display_name=f"distro{i}") for i in range(10)]
 
         filtered_distros = under_test._filter_non_matching_distros(
-            optional_distros, re.compile("#")
+            distros, None
         )
 
-        assert 0 == len(filtered_distros)
-        for distro in optional_distros:
-            assert distro not in filtered_distros
+        assert len(distros) == len(filtered_distros)
 
 
 class TestGetFlippedTasks:


### PR DESCRIPTION
I ran into an issue today (stack trace pasted below). The issue happened because the task mapping work item being processed did not have a build regex on it, so passing the work item's `build_variant_regex` to `create_task_mappings` (which happens [here](https://github.com/mongodb/selected-tests/blob/3f25da472f1c59885a6b5fab077f98c82435dfbd/src/selectedtests/work_items/process_work_items.py#L127)) caused an error where `build_variant_regex` was not being defined, because it was passed in as `None`. I talked to @dbradf and he suggested we set the default inside the `_filter_non_matching_distros` method instead.

```
(selected-tests-3.7.3) ~/m/selected-tests ❯❯❯ ./cronjobs/process_task_mapping_work_items.sh
INFO:selectedtests.work_items.process_work_items:2019-11-20 17:31.33 Starting task mapping work item processing for work_item module=None project=evergreen.py
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Starting to generate task mappings after_date=datetime.datetime(2019, 6, 5, 22, 31, 33, 257964) before_date=datetime.datetime(2019, 11, 20, 22, 31, 33, 257964) module=None project=evergreen.py
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_27864f17401c58e6311bd1e366a7679db4505172
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_51046015a8b60d2b5e71689d19dae22a7d7ddb48
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_b2884f549158e8fae02ae32de4d41d45485b61a1
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_07ae4094e19e5ffdf7e4fef910c3e3542d71bc02
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_950a06837995c5e4ad67a11eac642a9ca2ae8e27
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_f3c5d5d0119aa6aa8639bad8ca794a3e4b85aaae
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_45c3168502866449368d77808c37867051b52348
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_dd54be5ce727819af26c0f5be9c356c0373f5341
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_628c73465a201e50ce8bde16963452a826076621
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_acc7dd49ff913f6e3b25fbe1b791f8e62b98f23d
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_1735466a1a111bc56d82029d32ee0f03058ea935
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.33 Processing mappings for version version=evergreen.py_e2824fa8c4c6130cad12ddbc3570570ae7408ae4
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_387c9a78c0f7da225895bec84457040852f9b014
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_58d4e012574557e8239fb32ceb5b08c63d4f995f
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_c8de2e23bee3ead52e2e43f490a8eabca6918260
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_1cf3585b2df6ce0b8cb7f97b5e141eed0d5e33c7
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_32c3a9c5ac42e32f6b7c6ee816fcad5f043def7b
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_e044cb062851310fc70a15fdc06aab2255a7bdfe
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_951f6f59449b8691e3b285ad5e9a4a5793fda9c6
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_1ac87e0d6dccc109fa16aa096ee68c66df96fb9f
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_a627b6bb674e97b899d9adade53fd461a463cbf6
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_f6225cf279e554794bc0ef57878cd2ec033d706c
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_8f5b4b7354b50146320e920a665156360d68a98a
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_2714f7b81618a6114ce623e4345705428184fd20
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_ba420ab58ffc8390635877f88d8fe51085653a7c
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_f1db09aca74ca53df0efeef1386896e7d9cb3da1
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_2c941e161f3b990d0c53242b6f602f28a5f59f53
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_4ffdf60c8633d17492a64191181248b1393f6c56
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_4161a74294bd49e5caa7efb2b16ab9a61fe71fad
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_69bb6222d13c39cfd33916577f0d2ce9c4b40403
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_a22ea7da8a39b5febb804e4016df4bbd3f0bb66f
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_bb9366554c7e7e09e4abfdb3ab59d5e68d7f4adb
INFO:selectedtests.task_mappings.mappings:2019-11-20 17:31.34 Processing mappings for version version=evergreen.py_769f46465dc460771cdcfca13a264e6899384736
WARNING:selectedtests.work_items.process_work_items:2019-11-20 17:31.34 Unexpected exception processing task mapping work item
Traceback (most recent call last):
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/work_items/process_work_items.py", line 57, in process_queued_task_mapping_work_items
    _process_one_task_mapping_work_item(work_item, evg_api, mongo, after_date, before_date)
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/work_items/process_work_items.py", line 93, in _process_one_task_mapping_work_item
    if _run_create_task_mappings(evg_api, mongo, work_item, after_date, before_date, log):
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/work_items/process_work_items.py", line 127, in _run_create_task_mappings
    work_item.build_variant_regex,
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/mappings.py", line 126, in create_task_mappings
    changed_files, flipped_tasks = job.result()
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/lib/python3.7/concurrent/futures/_base.py", line 425, in result
    return self.__get_result()
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/mappings.py", line 296, in _process_evg_version
    flipped_tasks = _get_flipped_tasks(prev_version, version, next_version, build_regex)
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/mappings.py", line 314, in _get_flipped_tasks
    builds = _filter_non_matching_distros(builds, build_regex)
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/mappings.py", line 274, in _filter_non_matching_distros
    return [build for build in builds if match(build_regex, build.display_name)]
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/mappings.py", line 274, in <listcomp>
    return [build for build in builds if match(build_regex, build.display_name)]
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/lib/python3.7/re.py", line 173, in match
    return _compile(pattern, flags).match(string)
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/lib/python3.7/re.py", line 285, in _compile
    raise TypeError("first argument must be string or compiled pattern")
TypeError: first argument must be string or compiled pattern
```