### PR TITLE
Remove unneeded before_date to make code less complex

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ Its options are described below.
                                   Example: 2019-10-11T19:10:38
                                   [required]
 
-  --before TEXT                   The date to stop analyzing the project at - has to be an iso date.
-                                  Example: 2019-10-11T19:10:38
-                                  [required]
-
   --source-file-regex TEXT        Regex to determine what files mappings will be created for.
                                   Example: '^src/mongo'
                                   [required]
@@ -96,10 +92,6 @@ Its options are described below.
   --verbose                       Show logs.
 
   --after TEXT                    The date to begin analyzing the project at - has to be an iso date.
-                                  Example: 2019-10-11T19:10:38
-                                  [required]
-
-  --before TEXT                   The date to stop analyzing the project at - has to be an iso date.
                                   Example: 2019-10-11T19:10:38
                                   [required]
 

--- a/src/selectedtests/task_mappings/create_task_mappings.py
+++ b/src/selectedtests/task_mappings/create_task_mappings.py
@@ -38,7 +38,6 @@ class TaskMappings:
         evg_api: EvergreenApi,
         evergreen_project: str,
         after_date: datetime,
-        before_date: datetime,
         file_regex: Pattern,
         module_name: str = None,
         module_file_regex: Pattern = None,
@@ -50,22 +49,16 @@ class TaskMappings:
         :param evg_api: An instance of the evg_api client
         :param evergreen_project: The name of the evergreen project to analyze.
         :param after_date: The date at which to start analyzing versions of the project.
-        :param before_date: The date up to which we should analyze versions of the project.
         :param file_regex: Regex pattern to match changed files against.
         :param module_name: Name of the module associated with the evergreen project to also analyze
         :param module_file_regex: Regex pattern to match changed files of the module against.
         :param build_regex: Regex pattern to match build variant names against. Defaults to None.
         :return: An instance of the task mappings class
         """
-        log = LOGGER.bind(
-            project=evergreen_project,
-            module=module_name,
-            after_date=after_date,
-            before_date=before_date,
-        )
+        log = LOGGER.bind(project=evergreen_project, module=module_name, after_date=after_date)
         log.info("Starting to generate task mappings")
         project_versions = evg_api.versions_by_project_time_window(
-            evergreen_project, before_date, after_date
+            evergreen_project, datetime.utcnow(), after_date
         )
 
         task_mappings = {}

--- a/src/selectedtests/task_mappings/task_mappings_cli.py
+++ b/src/selectedtests/task_mappings/task_mappings_cli.py
@@ -48,13 +48,6 @@ def cli(ctx, verbose: bool):
     required=True,
 )
 @click.option(
-    "--before",
-    type=str,
-    help="The date to stop analyzing the project at - has to be an iso date. "
-    "Example: 2019-10-11T19:10:38",
-    required=True,
-)
-@click.option(
     "--source-file-regex",
     type=str,
     help="Regex that will be used to map what files mappings will be created for. "
@@ -87,7 +80,6 @@ def create(
     ctx,
     evergreen_project: str,
     after: str,
-    before: str,
     source_file_regex: str,
     module_name: str,
     module_source_file_regex: str,
@@ -99,10 +91,9 @@ def create(
 
     try:
         after_date = datetime.fromisoformat(after)
-        before_date = datetime.fromisoformat(before)
     except ValueError:
         raise click.ClickException(
-            "The after or before date could not be parsed - make sure it's an iso date"
+            "The after date could not be parsed - make sure it's an iso date"
         )
 
     file_regex = re.compile(source_file_regex)
@@ -126,7 +117,6 @@ def create(
         evg_api,
         evergreen_project,
         after_date,
-        before_date,
         file_regex,
         module_name,
         module_file_regex,

--- a/src/selectedtests/test_mappings/test_mappings_cli.py
+++ b/src/selectedtests/test_mappings/test_mappings_cli.py
@@ -46,13 +46,6 @@ def cli(ctx, verbose: str):
     required=True,
 )
 @click.option(
-    "--before",
-    type=str,
-    help="The date to stop analyzing the project at - has to be an iso date. "
-    "Example: 2019-10-11T19:10:38",
-    required=True,
-)
-@click.option(
     "--source-file-regex",
     type=str,
     help="Regex that will be used to map what files mappings will be created for. "
@@ -83,7 +76,6 @@ def create(
     ctx,
     evergreen_project: str,
     after: str,
-    before: str,
     source_file_regex: str,
     test_file_regex: str,
     module_name: str,
@@ -96,10 +88,9 @@ def create(
 
     try:
         after_date = datetime.fromisoformat(after).replace(tzinfo=pytz.UTC)
-        before_date = datetime.fromisoformat(before).replace(tzinfo=pytz.UTC)
     except ValueError:
         raise click.ClickException(
-            "The after or before date could not be parsed - make sure it's an iso date"
+            "The after date could not be parsed - make sure it's an iso date"
         )
         return
 
@@ -129,7 +120,6 @@ def create(
         source_re,
         test_re,
         after_date,
-        before_date,
         module_name,
         module_source_re,
         module_test_re,

--- a/src/selectedtests/work_items/process_work_items.py
+++ b/src/selectedtests/work_items/process_work_items.py
@@ -41,7 +41,7 @@ def _clear_in_progress_work(collection: Collection):
 
 
 def process_queued_task_mapping_work_items(
-    evg_api: EvergreenApi, mongo: MongoWrapper, after_date: datetime, before_date: datetime
+    evg_api: EvergreenApi, mongo: MongoWrapper, after_date: datetime
 ):
     """
     Process task mapping work items that have not yet been processed.
@@ -49,12 +49,11 @@ def process_queued_task_mapping_work_items(
     :param evg_api: An instance of the evg_api client
     :param mongo: An instance of MongoWrapper.
     :param after_date: The date at which to start analyzing commits of the project.
-    :param before_date: The date up to which we should analyze commits of the project.
     """
     _clear_in_progress_work(mongo.task_mappings_queue())
     try:
         for work_item in _generate_task_mapping_work_items(mongo):
-            _process_one_task_mapping_work_item(work_item, evg_api, mongo, after_date, before_date)
+            _process_one_task_mapping_work_item(work_item, evg_api, mongo, after_date)
     except:  # noqa: E722
         LOGGER.warning("Unexpected exception processing task mapping work item", exc_info=1)
 
@@ -77,7 +76,6 @@ def _process_one_task_mapping_work_item(
     evg_api: EvergreenApi,
     mongo: MongoWrapper,
     after_date: datetime,
-    before_date: datetime,
 ):
     """
     Process a task mapping work item.
@@ -86,11 +84,10 @@ def _process_one_task_mapping_work_item(
     :param evg_api: An instance of the evg_api client
     :param mongo: An instance of MongoWrapper.
     :param after_date: The date at which to start analyzing commits of the project.
-    :param before_date: The date up to which we should analyze commits of the project.
     """
     log = LOGGER.bind(project=work_item.project, module=work_item.module)
     log.info("Starting task mapping work item processing for work_item")
-    if _run_create_task_mappings(evg_api, mongo, work_item, after_date, before_date, log):
+    if _run_create_task_mappings(evg_api, mongo, work_item, after_date, log):
         work_item.complete(mongo.task_mappings_queue())
 
 
@@ -99,7 +96,6 @@ def _run_create_task_mappings(
     mongo: MongoWrapper,
     work_item: ProjectTaskMappingWorkItem,
     after_date: datetime,
-    before_date: datetime,
     log: Any,
 ) -> bool:
     """
@@ -109,7 +105,6 @@ def _run_create_task_mappings(
     :param mongo: An instance of MongoWrapper.
     :param work_item: An instance of ProjectTestMappingWorkItem.
     :param after_date: The date at which to start analyzing commits of the project.
-    :param before_date: The date up to which we should analyze commits of the project.
     """
     source_re = re.compile(work_item.source_file_regex)
     module_source_re = None
@@ -120,7 +115,6 @@ def _run_create_task_mappings(
         evg_api,
         work_item.project,
         after_date,
-        before_date,
         source_re,
         module_name=work_item.module,
         module_file_regex=module_source_re,
@@ -135,7 +129,7 @@ def _run_create_task_mappings(
 
 
 def process_queued_test_mapping_work_items(
-    evg_api: EvergreenApi, mongo: MongoWrapper, after_date: datetime, before_date: datetime
+    evg_api: EvergreenApi, mongo: MongoWrapper, after_date: datetime
 ):
     """
     Process test mapping work items that have not yet been processed.
@@ -143,12 +137,11 @@ def process_queued_test_mapping_work_items(
     :param evg_api: An instance of the evg_api client
     :param mongo: An instance of MongoWrapper.
     :param after_date: The date at which to start analyzing commits of the project.
-    :param before_date: The date up to which we should analyze commits of the project.
     """
     _clear_in_progress_work(mongo.test_mappings_queue())
     try:
         for work_item in _generate_test_mapping_work_items(mongo):
-            _process_one_test_mapping_work_item(work_item, evg_api, mongo, after_date, before_date)
+            _process_one_test_mapping_work_item(work_item, evg_api, mongo, after_date)
     except:  # noqa: E722
         LOGGER.warning("Unexpected exception processing test mapping work item", exc_info=1)
 
@@ -171,7 +164,6 @@ def _process_one_test_mapping_work_item(
     evg_api: EvergreenApi,
     mongo: MongoWrapper,
     after_date: datetime,
-    before_date: datetime,
 ):
     """
     Process a test mapping work item.
@@ -180,12 +172,11 @@ def _process_one_test_mapping_work_item(
     :param evg_api: An instance of the evg_api client
     :param mongo: An instance of MongoWrapper.
     :param after_date: The date at which to start analyzing commits of the project.
-    :param before_date: The date up to which we should analyze commits of the project.
     :return: Whether all work items have been processed.
     """
     log = LOGGER.bind(project=work_item.project, module=work_item.module)
     log.info("Starting test mapping work item processing for work_item")
-    if _run_create_test_mappings(evg_api, mongo, work_item, after_date, before_date, log):
+    if _run_create_test_mappings(evg_api, mongo, work_item, after_date, log):
         work_item.complete(mongo.test_mappings_queue())
 
 
@@ -194,7 +185,6 @@ def _run_create_test_mappings(
     mongo: MongoWrapper,
     work_item: ProjectTestMappingWorkItem,
     after_date: datetime,
-    before_date: datetime,
     log: Any,
 ) -> bool:
     """
@@ -204,7 +194,6 @@ def _run_create_test_mappings(
     :param mongo: An instance of MongoWrapper.
     :param work_item: An instance of ProjectTestMappingWorkItem.
     :param after_date: The date at which to start analyzing commits of the project.
-    :param before_date: The date up to which we should analyze commits of the project.
     """
     source_re = re.compile(work_item.source_file_regex)
     test_re = re.compile(work_item.test_file_regex)
@@ -220,7 +209,6 @@ def _run_create_test_mappings(
         source_re,
         test_re,
         after_date,
-        before_date,
         module_name=work_item.module,
         module_source_re=module_source_re,
         module_test_re=module_test_re,

--- a/src/selectedtests/work_items/work_items_cli.py
+++ b/src/selectedtests/work_items/work_items_cli.py
@@ -65,14 +65,12 @@ def create_test_mapping(ctx, project: str, src_regex: str, test_file_regex: str)
 @click.pass_context
 def process_test_mappings(ctx, weeks_back):
     """Process test mapping work items that have not yet been processed."""
-    # For test mappings, before_date and after_date are compared against git commit
-    # committed_datetime, which is stored in a UTC date format that is UTC offset-aware. So
-    # before_date and after_date need to be offset-aware, which is why we add tzinfo below.
-    before_date = datetime.utcnow().replace(tzinfo=pytz.UTC)
-    after_date = before_date - timedelta(weeks=weeks_back)
-    process_queued_test_mapping_work_items(
-        ctx.obj["evg_api"], ctx.obj["mongo"], after_date, before_date
-    )
+    # For test mappings, after_date is compared against git commit committed_datetime, which is
+    # stored in a UTC date format that is UTC offset-aware. So after_date needs to be offset-aware,
+    # which is why we add tzinfo below.
+    now = datetime.utcnow().replace(tzinfo=pytz.UTC)
+    after_date = now - timedelta(weeks=weeks_back)
+    process_queued_test_mapping_work_items(ctx.obj["evg_api"], ctx.obj["mongo"], after_date)
 
 
 @cli.command()
@@ -111,14 +109,11 @@ def create_task_mapping(ctx, project: str, src_regex: str, build_regex: str):
 @click.pass_context
 def process_task_mappings(ctx, weeks_back):
     """Process task mapping work items that have not yet been processed."""
-    # For task mappings, before_date and after_date are compared against evergreen version
-    # create_time, which is stored in a UTC date format that is not UTC offset-aware. So before_date
-    # and after_date do not need to be offset-aware.
-    before_date = datetime.utcnow()
-    after_date = before_date - timedelta(weeks=weeks_back)
-    process_queued_task_mapping_work_items(
-        ctx.obj["evg_api"], ctx.obj["mongo"], after_date, before_date
-    )
+    # For task mappings, after_date is compared against evergreen version create_time, which is
+    # stored in a UTC date format that is not UTC offset-aware. So after_date does not need to be
+    # offset-aware.
+    after_date = datetime.utcnow() - timedelta(weeks=weeks_back)
+    process_queued_task_mapping_work_items(ctx.obj["evg_api"], ctx.obj["mongo"], after_date)
 
 
 def main():

--- a/tests/selectedtests/conftest.py
+++ b/tests/selectedtests/conftest.py
@@ -161,7 +161,7 @@ def repo_with_no_source_files_and_one_test_file_changed():
 
 
 @pytest.fixture(scope="module")
-def repo_with_one_source_file_and_one_test_file_changed_in_same_commit():
+def repo_with_one_source_and_test_file_changed_in_same_commit():
     def _repo(temp_directory):
         repo = initialize_temp_repo(temp_directory)
         source_file = os.path.join(temp_directory, "new-source-file")
@@ -192,13 +192,13 @@ def repo_with_one_source_file_and_one_test_file_changed_in_different_commits():
     return _repo
 
 
-@pytest.fixture(scope="module")
-def repo_with_files_added_two_days_ago():
-    def _repo(temp_directory):
-        two_days_ago = str(datetime.combine(datetime.now() - timedelta(days=2), time()))
-        os.environ["GIT_AUTHOR_DATE"] = two_days_ago
-        os.environ["GIT_COMMITTER_DATE"] = two_days_ago
+@pytest.fixture(scope="function")
+def repo_with_files_added_two_days_ago(monkeypatch):
+    two_days_ago = str(datetime.combine(datetime.now() - timedelta(days=2), time()))
+    monkeypatch.setenv("GIT_AUTHOR_DATE", two_days_ago)
+    monkeypatch.setenv("GIT_COMMITTER_DATE", two_days_ago)
 
+    def _repo(temp_directory):
         repo = initialize_temp_repo(temp_directory)
         source_file = os.path.join(temp_directory, "new-source-file")
         test_file = os.path.join(temp_directory, "new-test-file")

--- a/tests/selectedtests/task_mappings/test_create_task_mappings.py
+++ b/tests/selectedtests/task_mappings/test_create_task_mappings.py
@@ -35,7 +35,6 @@ class TestFullRunThrough:
             mock_evg_api,
             project_name,
             datetime.fromisoformat("2019-10-11T19:10:38"),
-            datetime.fromisoformat("2019-10-11T19:30:38"),
             re.compile("src.*"),
         )
 
@@ -77,10 +76,14 @@ class TestCreateTaskMappings:
         project_name = "project"
 
         after = datetime.combine(date(1, 1, 1), time(1, 1, 0))
-        before = datetime.combine(date(1, 1, 1), time(1, 3, 0))
 
         mappings = under_test.TaskMappings.create_task_mappings(
-            evg_api_mock, project_name, after, before, None, "module", None
+            evg_api_mock,
+            project_name,
+            after,
+            file_regex=None,
+            module_name="module",
+            module_file_regex=None,
         )
 
         assert len(expected_file_list) == len(mappings.mappings)
@@ -129,10 +132,14 @@ class TestCreateTaskMappings:
         project_name = "project"
 
         after = datetime.combine(date(1, 1, 1), time(1, 1, 0))
-        before = datetime.combine(date(1, 1, 1), time(1, 3, 0))
 
         mappings = under_test.TaskMappings.create_task_mappings(
-            evg_api_mock, project_name, after, before, None, "", None
+            evg_api_mock,
+            project_name,
+            after,
+            file_regex=None,
+            module_name="",
+            module_file_regex=None,
         )
 
         assert len(expected_file_list) == len(mappings.mappings)
@@ -170,10 +177,14 @@ class TestCreateTaskMappings:
         project_name = "project"
 
         after = datetime.combine(date(1, 1, 1), time(1, 1, 0))
-        before = datetime.combine(date(1, 1, 1), time(1, 3, 0))
 
         mappings = under_test.TaskMappings.create_task_mappings(
-            evg_api_mock, project_name, after, before, None, "", None
+            evg_api_mock,
+            project_name,
+            after,
+            file_regex=None,
+            module_name="",
+            module_file_regex=None,
         )
 
         assert 0 == len(mappings.mappings)
@@ -196,12 +207,17 @@ class TestCreateTaskMappings:
         project_name = "project"
 
         after = datetime.combine(date(1, 1, 1), time(1, 1, 0))
-        before = datetime.combine(date(1, 1, 1), time(1, 3, 0))
 
         build_regex = re.compile("is_this_passed_correctly")
 
         under_test.TaskMappings.create_task_mappings(
-            evg_api_mock, project_name, after, before, None, "", None, build_regex
+            evg_api_mock,
+            project_name,
+            after,
+            file_regex=None,
+            module_name="",
+            module_file_regex=None,
+            build_regex=build_regex,
         )
 
         assert build_regex == non_matching_filter_mock.call_args[0][1]

--- a/tests/selectedtests/task_mappings/test_task_mappings_cli.py
+++ b/tests/selectedtests/task_mappings/test_task_mappings_cli.py
@@ -41,8 +41,6 @@ class TestCli:
                     output_file,
                     "--after",
                     "2019-10-11T19:10:38",
-                    "--before",
-                    "2019-10-11T19:30:38",
                 ],
             )
             assert result.exit_code == 0
@@ -75,14 +73,11 @@ class TestCli:
                     output_file,
                     "--after",
                     "2019",
-                    "--before",
-                    "2019",
                 ],
             )
             assert result.exit_code == 1
             assert (
-                "The after or before date could not be parsed - make sure it's an iso date"
-                in result.stdout
+                "The after date could not be parsed - make sure it's an iso date" in result.stdout
             )
 
     @patch(ns("RetryingEvergreenApi"))
@@ -108,8 +103,6 @@ class TestCli:
                     output_file,
                     "--after",
                     "2019-10-11T19:10:38",
-                    "--before",
-                    "2019-10-11T19:30:38",
                 ],
             )
             assert result.exit_code == 1

--- a/tests/selectedtests/test_mappings/test_test_mappings_cli.py
+++ b/tests/selectedtests/test_mappings/test_test_mappings_cli.py
@@ -42,8 +42,6 @@ class TestCli:
                     output_file,
                     "--after",
                     "2019-10-11T19:10:38",
-                    "--before",
-                    "2019-10-11T19:30:38",
                 ],
             )
             assert result.exit_code == 0
@@ -80,14 +78,11 @@ class TestCli:
                     output_file,
                     "--after",
                     "2019",
-                    "--before",
-                    "2019",
                 ],
             )
             assert result.exit_code == 1
             assert (
-                "The after or before date could not be parsed - make sure it's an iso date"
-                in result.stdout
+                "The after date could not be parsed - make sure it's an iso date" in result.stdout
             )
 
     @patch(ns("RetryingEvergreenApi"))
@@ -115,8 +110,6 @@ class TestCli:
                     output_file,
                     "--after",
                     "2019-10-11T19:10:38",
-                    "--before",
-                    "2019-10-11T19:30:38",
                 ],
             )
             assert result.exit_code == 1

--- a/tests/selectedtests/work_items/test_process_work_items.py
+++ b/tests/selectedtests/work_items/test_process_work_items.py
@@ -30,7 +30,7 @@ class TestProcessQueuedTaskMappingWorkItems:
         evg_api_mock = MagicMock()
         mongo_mock = MagicMock()
 
-        under_test.process_queued_task_mapping_work_items(evg_api_mock, mongo_mock, None, None)
+        under_test.process_queued_task_mapping_work_items(evg_api_mock, mongo_mock, after_date=None)
 
         assert n_work_items == mock_process_one_task_mapping_work_item.call_count
 
@@ -40,7 +40,7 @@ class TestProcessQueuedTaskMappingWorkItems:
         evg_api_mock = MagicMock()
         mongo_mock = MagicMock()
 
-        under_test.process_queued_task_mapping_work_items(evg_api_mock, mongo_mock, None, None)
+        under_test.process_queued_task_mapping_work_items(evg_api_mock, mongo_mock, after_date=None)
 
 
 class TestGenerateTaskMappingWorkItems:
@@ -75,7 +75,7 @@ class TestProcessOneTaskMappingWorkItem:
         mongo_mock = MagicMock()
 
         under_test._process_one_task_mapping_work_item(
-            work_item_mock, evg_api_mock, mongo_mock, None, None
+            work_item_mock, evg_api_mock, mongo_mock, after_date=None
         )
 
         work_item_mock.complete.assert_called_once()
@@ -90,7 +90,7 @@ class TestProcessOneTaskMappingWorkItem:
         mongo_mock = MagicMock()
 
         under_test._process_one_task_mapping_work_item(
-            work_item_mock, evg_api_mock, mongo_mock, None, None
+            work_item_mock, evg_api_mock, mongo_mock, after_date=None
         )
 
         work_item_mock.next.return_value.complete.assert_not_called()
@@ -108,7 +108,7 @@ class TestRunCreateTaskMappings:
         work_item_mock = MagicMock(source_file_regex="src", module=None)
 
         under_test._run_create_task_mappings(
-            evg_api_mock, mongo_mock, work_item_mock, None, None, logger_mock
+            evg_api_mock, mongo_mock, work_item_mock, after_date=None, log=logger_mock
         )
 
         mongo_mock.task_mappings.return_value.insert_many.assert_called_once_with(["mock-response"])
@@ -127,7 +127,7 @@ class TestRunCreateTaskMappings:
         work_item_mock = MagicMock(source_file_regex="src", module=None)
 
         under_test._run_create_task_mappings(
-            evg_api_mock, mongo_mock, work_item_mock, None, None, logger_mock
+            evg_api_mock, mongo_mock, work_item_mock, after_date=None, log=logger_mock
         )
 
         mongo_mock.task_mappings.return_value.insert_many.assert_not_called()
@@ -145,7 +145,7 @@ class TestProcessQueuedTestMappingWorkItems:
         evg_api_mock = MagicMock()
         mongo_mock = MagicMock()
 
-        under_test.process_queued_test_mapping_work_items(evg_api_mock, mongo_mock, None, None)
+        under_test.process_queued_test_mapping_work_items(evg_api_mock, mongo_mock, after_date=None)
 
         assert n_work_items == mock_process_one_test_mapping_work_item.call_count
 
@@ -155,7 +155,7 @@ class TestProcessQueuedTestMappingWorkItems:
         evg_api_mock = MagicMock()
         mongo_mock = MagicMock()
 
-        under_test.process_queued_test_mapping_work_items(evg_api_mock, mongo_mock, None, None)
+        under_test.process_queued_test_mapping_work_items(evg_api_mock, mongo_mock, after_date=None)
 
 
 class TestProcessOneTestMappingWorkItem:
@@ -169,7 +169,7 @@ class TestProcessOneTestMappingWorkItem:
         mongo_mock = MagicMock()
 
         under_test._process_one_test_mapping_work_item(
-            work_item_mock, evg_api_mock, mongo_mock, None, None
+            work_item_mock, evg_api_mock, mongo_mock, after_date=None
         )
 
         work_item_mock.complete.assert_called_once()
@@ -184,7 +184,7 @@ class TestProcessOneTestMappingWorkItem:
         mongo_mock = MagicMock()
 
         under_test._process_one_test_mapping_work_item(
-            work_item_mock, evg_api_mock, mongo_mock, None, None
+            work_item_mock, evg_api_mock, mongo_mock, after_date=None
         )
 
         work_item_mock.complete.assert_not_called()
@@ -200,7 +200,7 @@ class TestRunCreateTestMappings:
         work_item_mock = MagicMock(source_file_regex="src", test_file_regex="test", module=None)
 
         under_test._run_create_test_mappings(
-            evg_api_mock, mongo_mock, work_item_mock, None, None, logger_mock
+            evg_api_mock, mongo_mock, work_item_mock, after_date=None, log=logger_mock
         )
 
         mongo_mock.test_mappings.return_value.insert_many.assert_called_once_with(["mock-mapping"])
@@ -217,7 +217,7 @@ class TestRunCreateTestMappings:
         work_item_mock = MagicMock(source_file_regex="src", test_file_regex="test", module=None)
 
         under_test._run_create_test_mappings(
-            evg_api_mock, mongo_mock, work_item_mock, None, None, logger_mock
+            evg_api_mock, mongo_mock, work_item_mock, after_date=None, log=logger_mock
         )
 
         mongo_mock.test_mappings.return_value.insert_many.assert_not_called()


### PR DESCRIPTION
This is some prework I wanted to do before starting on https://jira.mongodb.org/browse/TIG-2001. 

Since the selected-tests service will not need the ability to conduct analysis on a specific date range, and instead will always run on data up the the current day, it does not make sense to specify a "before_date". 