### PR TITLE
MAKE-1054 Handle cases where previous version did not contain build for buildvariant

### DIFF
--- a/src/selectedtests/task_mappings/create_task_mappings.py
+++ b/src/selectedtests/task_mappings/create_task_mappings.py
@@ -326,8 +326,21 @@ def _get_flipped_tasks_per_build(
     :param next_version: The child version of the version the given build belongs to.
     :return: A list of all the flipped tasks that happened in the given build.
     """
-    prev_build: Build = prev_version.build_by_variant(build.build_variant)
-    next_build: Build = next_version.build_by_variant(build.build_variant)
+    try:
+        prev_build: Build = prev_version.build_by_variant(build.build_variant)
+    except KeyError:
+        LOGGER.warning(
+            "Previous version does not contain a build for this build variant", exc_info=True
+        )
+        return []
+
+    try:
+        next_build: Build = next_version.build_by_variant(build.build_variant)
+    except KeyError:
+        LOGGER.warning(
+            "Next version does not contain a build for this build variant", exc_info=True
+        )
+        return []
 
     prev_tasks = _create_task_map(prev_build.get_tasks())
     next_tasks = _create_task_map(next_build.get_tasks())


### PR DESCRIPTION
I ran into the below issue when creating task mappings recently. On Nov 2 there was an Evergreen bug that allowed some mainline versions to not run builds on required buildvariants, so for example, there were versions that had no build that ran on 'enterprise-rhel-62-64-bit' or 'enterprise-rhel-62-64-bit-majority-read-concern-off'.

Before:
```
❯❯❯ task-mappings create mongodb-mongo-master --module-name enterprise --after 2019-12-02T00:00:12 --source-file-regex "^src/mongo" --module-source-file-regex "^src" --output-file output.txt
...
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
Traceback (most recent call last):
  File "/Users/lydia.stepanek/.pyenv/versions/selected-tests-3.7.3/bin/task-mappings", line 11, in <module>
    load_entry_point('selectedtests', 'console_scripts', 'task-mappings')()
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/task_mappings_cli.py", line 141, in main
    return cli(obj={})
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/envs/selected-tests-3.7.3/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/envs/selected-tests-3.7.3/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/envs/selected-tests-3.7.3/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/envs/selected-tests-3.7.3/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/envs/selected-tests-3.7.3/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/envs/selected-tests-3.7.3/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/task_mappings_cli.py", line 123, in create
    build_regex,
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/create_task_mappings.py", line 104, in create_task_mappings
    flipped_tasks = _get_flipped_tasks(prev_version, version, next_version, build_regex)
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/create_task_mappings.py", line 299, in _get_flipped_tasks
    flipped_tasks_in_build = _get_flipped_tasks_per_build(build, prev_version, next_version)
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/create_task_mappings.py", line 316, in _get_flipped_tasks_per_build
    prev_build: Build = prev_version.build_by_variant(build.build_variant)
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/envs/selected-tests-3.7.3/lib/python3.7/site-packages/evergreen/version.py", line 82, in build_by_variant
    return self._api.build_by_id(self.build_variants_map[build_variant])
KeyError: 'enterprise-rhel-62-64-bit'
```

After:
```
❯❯❯ task-mappings create mongodb-mongo-master --module-name enterprise --after 2019-12-02T00:00:12 --source-file-regex "^src/mongo" --module-source-file-regex "^src" --output-file output.txt
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:selectedtests.task_mappings.create_task_mappings:2019-12-05 10:29.05 Previous version does not contain a build for this build variant
Traceback (most recent call last):
  File "/Users/lydia.stepanek/mongo/selected-tests/src/selectedtests/task_mappings/create_task_mappings.py", line 330, in _get_flipped_tasks_per_build
    prev_build: Build = prev_version.build_by_variant(build.build_variant)
  File "/Users/lydia.stepanek/.pyenv/versions/3.7.3/envs/selected-tests-3.7.3/lib/python3.7/site-packages/evergreen/version.py", line 82, in build_by_variant
    return self._api.build_by_id(self.build_variants_map[build_variant])
KeyError: 'enterprise-rhel-62-64-bit-majority-read-concern-off'
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: evergreen.mongodb.com
INFO:selectedtests.task_mappings.create_task_mappings:2019-12-05 10:30.30 Generated task mappings list   task_mappings_length=228
INFO:selectedtests.task_mappings.task_mappings_cli:2019-12-05 10:30.30 Finished processing task mappings
```