### PR TITLE
Avoid using source command in setup_ssh_keys shell script

### DIFF
--- a/cronjobs/process_task_mapping_work_items.sh
+++ b/cronjobs/process_task_mapping_work_items.sh
@@ -3,7 +3,7 @@
 SSH_DIR=$HOME/.ssh
 FILE_DIR=$(dirname "$0")
 
-source "$FILE_DIR/lib/setup_ssh_keys.sh"
+. "$FILE_DIR/lib/setup_ssh_keys.sh"
 setup_ssh_keys "$SSH_DIR"
 
 export LC_ALL=C.UTF-8

--- a/cronjobs/process_test_mapping_work_items.sh
+++ b/cronjobs/process_test_mapping_work_items.sh
@@ -3,7 +3,7 @@
 SSH_DIR=$HOME/.ssh
 FILE_DIR=$(dirname "$0")
 
-source "$FILE_DIR/lib/setup_ssh_keys.sh"
+. "$FILE_DIR/lib/setup_ssh_keys.sh"
 setup_ssh_keys "$SSH_DIR"
 
 export LC_ALL=C.UTF-8

--- a/cronjobs/update_task_mappings.sh
+++ b/cronjobs/update_task_mappings.sh
@@ -3,7 +3,7 @@
 SSH_DIR=$HOME/.ssh
 FILE_DIR=$(dirname "$0")
 
-source "$FILE_DIR/lib/setup_ssh_keys.sh"
+. "$FILE_DIR/lib/setup_ssh_keys.sh"
 setup_ssh_keys "$SSH_DIR"
 
 export LC_ALL=C.UTF-8

--- a/cronjobs/update_test_mappings.sh
+++ b/cronjobs/update_test_mappings.sh
@@ -3,7 +3,7 @@
 SSH_DIR=$HOME/.ssh
 FILE_DIR=$(dirname "$0")
 
-source "$FILE_DIR/lib/setup_ssh_keys.sh"
+. "$FILE_DIR/lib/setup_ssh_keys.sh"
 setup_ssh_keys "$SSH_DIR"
 
 export LC_ALL=C.UTF-8


### PR DESCRIPTION
The cronjobs to process mappings were encountering the following error because [the source command is not found in the shell](https://stackoverflow.com/questions/13702425/source-command-not-found-in-sh-shell/13702462) that we use in Kanopy:
```
root@f0b822630126:/selected-tests# sh -x cronjobs/process_test_mapping_work_items.sh
+ SSH_DIR=/root/.ssh
+ dirname cronjobs/process_test_mapping_work_items.sh
+ FILE_DIR=cronjobs
+ source cronjobs/lib/setup_ssh_keys.sh
cronjobs/process_test_mapping_work_items.sh: 6: cronjobs/process_test_mapping_work_items.sh: source: not found
+ setup_ssh_keys /root/.ssh
cronjobs/process_test_mapping_work_items.sh: 7: cronjobs/process_test_mapping_work_items.sh: setup_ssh_keys: not found
+ export LC_ALL=C.UTF-8
+ export LANG=C.UTF-8
+ work-items process-test-mappings
INFO:selectedtests.work_items.process_test_mapping_work_items:2020-01-07 18:14.33 Starting test mapping work item processing for work_item module=enterprise project=mongodb-mongo-master
```

After fix:
```
root@be5785f032c4:/selected-tests# sh -x cronjobs/process_test_mapping_work_items.sh
+ SSH_DIR=/root/.ssh
+ dirname cronjobs/process_test_mapping_work_items.sh
+ FILE_DIR=cronjobs
+ . cronjobs/lib/setup_ssh_keys.sh
+ setup_ssh_keys /root/.ssh
+ local target_dir=/root/.ssh
+ [ ! -d /root/.ssh ]
+ ssh-keyscan -t rsa github.com
# github.com:22 SSH-2.0-babeld-778045a0
+ cat
+ chmod 600 /root/.ssh/id_rsa
+ cat
+ export LC_ALL=C.UTF-8
+ export LANG=C.UTF-8
+ work-items process-test-mappings
{"message": "Starting test mapping work item processing for work_item", "lineno": 79, "filename": "process_test_mapping_work_items.py", "project": "mongodb-mongo-master", "evergreen_module": "enterprise", "logger": "contextlib", "level": "info"}
```