### PR TITLE
MAKE-1120 specify resources.

### DIFF
--- a/cronjobs.yml
+++ b/cronjobs.yml
@@ -11,38 +11,38 @@ cronJobs:
     command: ["/bin/sh", "cronjobs/process_test_mapping_work_items.sh"]
     resources: # Burstable
       requests: # guaranteed amount of resources
-        cpu: 10m
-        memory: 5Mi
+        cpu: "10m"
+        memory: "5Mi"
       limits: # maximum allowed resources
-        cpu: 20m
-        memory: 10Mi
+        cpu: "1.5"
+        memory: "600Mi"
   - name: process-task-mappings
     schedule: "0 2 * * *"
     command: ["/bin/sh", "cronjobs/process_task_mapping_work_items.sh"]
     resources: # Burstable
       requests: # guaranteed amount of resources
-        cpu: 10m
-        memory: 5Mi
+        cpu: "10m"
+        memory: "5Mi"
       limits: # maximum allowed resources
-        cpu: 20m
-        memory: 10Mi
+        cpu: "2.5"
+        memory: "1.5Gi"
   - name: update-test-mappings
     schedule: "0 3 * * *"
     command: ["/bin/sh", "cronjobs/update_test_mappings.sh"]
     resources: # Burstable
       requests: # guaranteed amount of resources
-        cpu: 400m
-        memory: 800Mi
+        cpu: "900m"
+        memory: "500Mi"
       limits: # maximum allowed resources
-        cpu: 600m
-        memory: 1.2Gi
+        cpu: "1"
+        memory: "750Mi"
   - name: update-task-mappings
     schedule: "0 4 * * *"
     command: ["/bin/sh", "cronjobs/update_task_mappings.sh"]
     resources: # Burstable
       requests: # guaranteed amount of resources
-        cpu: 1
-        memory: 2.25Gi
+        cpu: "1.1"
+        memory: "800Mi"
       limits: # maximum allowed resources
-        cpu: 1.5
-        memory: 3.375Gi
+        cpu: "1.2"
+        memory: "1Gi"

--- a/cronjobs.yml
+++ b/cronjobs.yml
@@ -11,38 +11,38 @@ cronJobs:
     command: ["/bin/sh", "cronjobs/process_test_mapping_work_items.sh"]
     resources: # Burstable
       requests: # guaranteed amount of resources
-        cpu: 500m
-        memory: 6Gi
+        cpu: 10m
+        memory: 5Mi
       limits: # maximum allowed resources
-        cpu: 2
-        memory: 12Gi
+        cpu: 20m
+        memory: 10Mi
   - name: process-task-mappings
     schedule: "0 2 * * *"
     command: ["/bin/sh", "cronjobs/process_task_mapping_work_items.sh"]
     resources: # Burstable
       requests: # guaranteed amount of resources
-        cpu: 500m
-        memory: 6Gi
+        cpu: 10m
+        memory: 5Mi
       limits: # maximum allowed resources
-        cpu: 2
-        memory: 12Gi
+        cpu: 20m
+        memory: 10Mi
   - name: update-test-mappings
     schedule: "0 3 * * *"
     command: ["/bin/sh", "cronjobs/update_test_mappings.sh"]
     resources: # Burstable
       requests: # guaranteed amount of resources
-        cpu: 500m
-        memory: 6Gi
+        cpu: 400m
+        memory: 800Mi
       limits: # maximum allowed resources
-        cpu: 2
-        memory: 12Gi
+        cpu: 600m
+        memory: 1.2Gi
   - name: update-task-mappings
     schedule: "0 4 * * *"
     command: ["/bin/sh", "cronjobs/update_task_mappings.sh"]
     resources: # Burstable
       requests: # guaranteed amount of resources
-        cpu: 500m
-        memory: 6Gi
+        cpu: 1
+        memory: 2.25Gi
       limits: # maximum allowed resources
-        cpu: 2
-        memory: 12Gi
+        cpu: 1.5
+        memory: 3.375Gi

--- a/cronjobs.yml
+++ b/cronjobs.yml
@@ -9,12 +9,40 @@ cronJobs:
   - name: process-test-mappings
     schedule: "0 1 * * *"
     command: ["/bin/sh", "cronjobs/process_test_mapping_work_items.sh"]
+    resources: # Burstable
+      requests: # guaranteed amount of resources
+        cpu: 500m
+        memory: 6Gi
+      limits: # maximum allowed resources
+        cpu: 2
+        memory: 12Gi
   - name: process-task-mappings
     schedule: "0 2 * * *"
     command: ["/bin/sh", "cronjobs/process_task_mapping_work_items.sh"]
+    resources: # Burstable
+      requests: # guaranteed amount of resources
+        cpu: 500m
+        memory: 6Gi
+      limits: # maximum allowed resources
+        cpu: 2
+        memory: 12Gi
   - name: update-test-mappings
     schedule: "0 3 * * *"
     command: ["/bin/sh", "cronjobs/update_test_mappings.sh"]
+    resources: # Burstable
+      requests: # guaranteed amount of resources
+        cpu: 500m
+        memory: 6Gi
+      limits: # maximum allowed resources
+        cpu: 2
+        memory: 12Gi
   - name: update-task-mappings
     schedule: "0 4 * * *"
     command: ["/bin/sh", "cronjobs/update_task_mappings.sh"]
+    resources: # Burstable
+      requests: # guaranteed amount of resources
+        cpu: 500m
+        memory: 6Gi
+      limits: # maximum allowed resources
+        cpu: 2
+        memory: 12Gi

--- a/environments/prod.yml
+++ b/environments/prod.yml
@@ -15,8 +15,8 @@ prometheusRules:
       summary: "Selected tests service giving high number of bad responses over the last hour (current number: {{ $value }}). More information can be seen here: https://grafana.corp.mongodb.com/d/zenZa6oWk/selected-tests-service?orgId=4"
 resources: # Burstable
   requests: # guaranteed amount of resources
-    cpu: 50m
-    memory: 100Mi
+    cpu: "5m"
+    memory: "30Mi"
   limits: # maximum allowed resources
-    cpu: 100m
-    memory: 200Mi
+    cpu: "50m"
+    memory: "100Mi"

--- a/environments/prod.yml
+++ b/environments/prod.yml
@@ -13,3 +13,10 @@ prometheusRules:
     annotations:
       description: "High number of bad responses coming from selected-tests service"
       summary: "Selected tests service giving high number of bad responses over the last hour (current number: {{ $value }}). More information can be seen here: https://grafana.corp.mongodb.com/d/zenZa6oWk/selected-tests-service?orgId=4"
+resources: # Burstable
+  requests: # guaranteed amount of resources
+    cpu: 500m
+    memory: 6Gi
+  limits: # maximum allowed resources
+    cpu: 2
+    memory: 12Gi

--- a/environments/prod.yml
+++ b/environments/prod.yml
@@ -15,8 +15,8 @@ prometheusRules:
       summary: "Selected tests service giving high number of bad responses over the last hour (current number: {{ $value }}). More information can be seen here: https://grafana.corp.mongodb.com/d/zenZa6oWk/selected-tests-service?orgId=4"
 resources: # Burstable
   requests: # guaranteed amount of resources
-    cpu: 500m
-    memory: 6Gi
+    cpu: 50m
+    memory: 100Mi
   limits: # maximum allowed resources
-    cpu: 2
-    memory: 12Gi
+    cpu: 100m
+    memory: 200Mi


### PR DESCRIPTION
The cron jobs are set as __Burstable__ as they will run again later. If the requests stanza is removed then they would be __Guaranteed__ and would have higher priority.

The prod configuration is also __Burstable__ , with the same (high) limits as the cronjobs, as we sometimes update the database in this container (although maybe we shouldn't be doing that).

