### PR TITLE
Increase web-app requests and limits

### DIFF
--- a/environments/prod.yml
+++ b/environments/prod.yml
@@ -16,11 +16,11 @@ prometheusRules:
       summary: "Selected tests service giving high number of bad responses over the last hour (current number: {{ $value }}). More information can be seen here: https://grafana.corp.mongodb.com/d/zenZa6oWk/selected-tests-service?orgId=4"
 resources: # Burstable
   requests: # guaranteed amount of resources
-    cpu: "5m"
-    memory: "30Mi"
-  limits: # maximum allowed resources
     cpu: "50m"
-    memory: "100Mi"
+    memory: "128Mi"
+  limits: # maximum allowed resources
+    cpu: "500m"
+    memory: "196Mi"
 probes:
   enabled: true
   path: /health


### PR DESCRIPTION
I was running the model evaluation script recently and started getting 502 error due to not having enough resources for requests to complete:
<img width="1609" alt="Screen Shot 2020-03-11 at 12 53 05 PM" src="https://user-images.githubusercontent.com/7087489/76444326-2bd95c00-639a-11ea-8859-e04a8d22259f.png">


I am increasing the CPU and Memory limits, assuming traffic will be higher than the number of requests I was making with my script today.