### PR TITLE
MAKE-1205: Fix ssh key creation in cronjobs

### DIFF
--- a/cronjobs/lib/setup_ssh_keys.sh
+++ b/cronjobs/lib/setup_ssh_keys.sh
@@ -1,38 +1,40 @@
 #!/usr/bin/env bash
 
-target_file=$1
+setup_ssh_keys() {
+  target_file=$1
 
-if [ -z "$GITHUB_PRIVATE_KEY" ]; then
-  echo "GITHUB_PRIVATE_KEY unset"
-  exit 1
-fi
+  if [ -z "$GITHUB_PRIVATE_KEY" ]; then
+    echo "GITHUB_PRIVATE_KEY unset"
+    exit 1
+  fi
 
-if [ -z "$GITHUB_PUBLIC_KEY" ]; then
-  echo "GITHUB_PUBLIC_KEY unset"
-  exit 1
-fi
+  if [ -z "$GITHUB_PUBLIC_KEY" ]; then
+    echo "GITHUB_PUBLIC_KEY unset"
+    exit 1
+  fi
 
-if [ ! -d "$HOME/.ssh" ]; then
+  if [ ! -d "$HOME/.ssh" ]; then
     mkdir "$HOME/.ssh"
     chmod 600 "$HOME/.ssh"
   fi
 
-if [ -f "$HOME/.ssh/$target_file" ]; then
-  echo "$target_file already exists"
-  exit 1
-fi
+  if [ -f "$HOME/.ssh/$target_file" ]; then
+    echo "$target_file already exists"
+    exit 1
+  fi
 
-# Make sure we have the right keys for github.
-ssh-keyscan -t rsa github.com >> "$HOME/.ssh/known_hosts"
+  # Make sure we have the right keys for github.
+  ssh-keyscan -t rsa github.com >> "$HOME/.ssh/known_hosts"
 
-cat > "$HOME/.ssh/$target_file" <<END_OF_PRIVATE
+  cat > "$HOME/.ssh/$target_file" <<END_OF_PRIVATE
 $GITHUB_PRIVATE_KEY
 END_OF_PRIVATE
-chmod 600 "$HOME/.ssh/$target_file"
+  chmod 600 "$HOME/.ssh/$target_file"
 
-cat > "$HOME/.ssh/$target_file.pub" <<END_OF_PUBLIC
+  cat > "$HOME/.ssh/$target_file.pub" <<END_OF_PUBLIC
 $GITHUB_PUBLIC_KEY
 END_OF_PUBLIC
 
-eval "$(ssh-agent -s)"
-ssh-add -k "$HOME/.ssh/$target_file"
+  eval "$(ssh-agent -s)"
+  ssh-add -k "$HOME/.ssh/$target_file"
+}

--- a/cronjobs/process_task_mapping_work_items.sh
+++ b/cronjobs/process_task_mapping_work_items.sh
@@ -2,7 +2,8 @@
 
 FILE_DIR=$(dirname "$0")
 
-. "$FILE_DIR/lib/setup_ssh_keys.sh" "selected_tests"
+. "$FILE_DIR/lib/setup_ssh_keys.sh"
+setup_ssh_keys "selected_tests"
 
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8

--- a/cronjobs/process_test_mapping_work_items.sh
+++ b/cronjobs/process_test_mapping_work_items.sh
@@ -2,7 +2,8 @@
 
 FILE_DIR=$(dirname "$0")
 
-. "$FILE_DIR/lib/setup_ssh_keys.sh" "selected_tests"
+. "$FILE_DIR/lib/setup_ssh_keys.sh"
+setup_ssh_keys "selected_tests"
 
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8

--- a/cronjobs/update_task_mappings.sh
+++ b/cronjobs/update_task_mappings.sh
@@ -2,7 +2,8 @@
 
 FILE_DIR=$(dirname "$0")
 
-. "$FILE_DIR/lib/setup_ssh_keys.sh" "selected_tests"
+. "$FILE_DIR/lib/setup_ssh_keys.sh"
+setup_ssh_keys "selected_tests"
 
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8

--- a/cronjobs/update_test_mappings.sh
+++ b/cronjobs/update_test_mappings.sh
@@ -2,7 +2,8 @@
 
 FILE_DIR=$(dirname "$0")
 
-. "$FILE_DIR/lib/setup_ssh_keys.sh" "selected_tests"
+. "$FILE_DIR/lib/setup_ssh_keys.sh"
+setup_ssh_keys "selected_tests"
 
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8


### PR DESCRIPTION
Sourcing a file in bash does not let you pass an argument to it. Instead we can create a function that we can pass in an argument to.