### PR TITLE
DAG-517 Upgrade python requests to prevent ConnectionResetErrors when accessing Evergreen /projects endpoint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,6 +28,7 @@ pipeline:
     tiller_ns: server-tig
     client_only: true
     values: "image.tag=git-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/server-tig/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=selected-tests.server-tig.staging.corp.mongodb.com"
+    values_files: ["environments/staging.yml"]
     when:
       branch: staging
       event: push

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -1,0 +1,6 @@
+replicaCount: 2
+env:
+  EVG_API_USER: evergreen-user
+envSecrets:
+  EVG_API_KEY: selected-tests-secrets
+  SELECTED_TESTS_MONGO_URI: selected-tests-secrets

--- a/poetry.lock
+++ b/poetry.lock
@@ -184,17 +184,16 @@ category = "main"
 description = "Python client for the Evergreen API"
 name = "evergreen.py"
 optional = false
-python-versions = "*"
-version = "1.0.2"
+python-versions = ">=3.6.1,<4.0.0"
+version = "1.4.8"
 
 [package.dependencies]
-Click = ">=7.0,<8.0"
-PyYAML = ">=5.1,<6.0"
-pylibversion = ">=0.1.0,<0.2.0"
-python-dateutil = ">=2.8.1,<2.9.0"
-requests = ">=2.22.0,<2.23.0"
-structlog = ">=19.1.0,<19.2.0"
-tenacity = ">=5.0.4,<5.1.0"
+Click = ">=7,<8"
+PyYAML = ">=5,<6"
+python-dateutil = ">=2,<3"
+requests = ">=2,<3"
+structlog = ">=19,<20"
+tenacity = ">=5,<6"
 
 [[package]]
 category = "main"
@@ -1090,7 +1089,7 @@ description = "YAML parser and emitter for Python"
 name = "pyyaml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "5.3"
+version = "5.3.1"
 
 [[package]]
 category = "dev"
@@ -1144,16 +1143,16 @@ description = "Python HTTP for Humans."
 name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.22.0"
+version = "2.24.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-chardet = ">=3.0.2,<3.1.0"
-idna = ">=2.5,<2.9"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
 
 [package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
@@ -1232,10 +1231,13 @@ description = "Retry code until it succeeeds"
 name = "tenacity"
 optional = false
 python-versions = "*"
-version = "5.0.4"
+version = "5.1.5"
 
 [package.dependencies]
 six = ">=1.9.0"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
 
 [[package]]
 category = "dev"
@@ -1397,7 +1399,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "9fe57ad0bce42ae12f0cfdb35eb9ed5953868e41a6714b95d7c25c60e8ceeb1e"
+content-hash = "5b4fff26d664e541629d943c6168234936f9ae1cf250a8a5b3ef4f6f3bc39f28"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -1503,8 +1505,8 @@ entrypoints = [
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
 ]
 "evergreen.py" = [
-    {file = "evergreen.py-1.0.2-py3-none-any.whl", hash = "sha256:b9ba7b9caa65305a2e534ab092a8917b3ae3a77436a10e505ea5a99ce79b419f"},
-    {file = "evergreen.py-1.0.2.tar.gz", hash = "sha256:2f4172e1d41e2f9bbb15a69000a623d8dc78d91ffbda3da847b1cac98397e600"},
+    {file = "evergreen.py-1.4.8-py3-none-any.whl", hash = "sha256:8a78bc799c4e302d3f8c1bf9f00c39d09c3f344bbef6b0664c3b0d96fe4f8ebe"},
+    {file = "evergreen.py-1.4.8.tar.gz", hash = "sha256:cc2294e63d02273c427b399ace9362e75f7d0e9bb569e4f3697b682cd4106cb4"},
 ]
 fastapi = [
     {file = "fastapi-0.45.0-py3-none-any.whl", hash = "sha256:3f626eda9b6edaa17c90c21a4d0d1a97a2a2fcba43a55f8c425b6b37e832c8bb"},
@@ -1952,17 +1954,17 @@ pywinpty = [
     {file = "pywinpty-0.5.7.tar.gz", hash = "sha256:2d7e9c881638a72ffdca3f5417dd1563b60f603e1b43e5895674c2a1b01f95a0"},
 ]
 pyyaml = [
-    {file = "PyYAML-5.3-cp27-cp27m-win32.whl", hash = "sha256:940532b111b1952befd7db542c370887a8611660d2b9becff75d39355303d82d"},
-    {file = "PyYAML-5.3-cp27-cp27m-win_amd64.whl", hash = "sha256:059b2ee3194d718896c0ad077dd8c043e5e909d9180f387ce42012662a4946d6"},
-    {file = "PyYAML-5.3-cp35-cp35m-win32.whl", hash = "sha256:4fee71aa5bc6ed9d5f116327c04273e25ae31a3020386916905767ec4fc5317e"},
-    {file = "PyYAML-5.3-cp35-cp35m-win_amd64.whl", hash = "sha256:dbbb2379c19ed6042e8f11f2a2c66d39cceb8aeace421bfc29d085d93eda3689"},
-    {file = "PyYAML-5.3-cp36-cp36m-win32.whl", hash = "sha256:e3a057b7a64f1222b56e47bcff5e4b94c4f61faac04c7c4ecb1985e18caa3994"},
-    {file = "PyYAML-5.3-cp36-cp36m-win_amd64.whl", hash = "sha256:74782fbd4d4f87ff04159e986886931456a1894c61229be9eaf4de6f6e44b99e"},
-    {file = "PyYAML-5.3-cp37-cp37m-win32.whl", hash = "sha256:24521fa2890642614558b492b473bee0ac1f8057a7263156b02e8b14c88ce6f5"},
-    {file = "PyYAML-5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:1cf708e2ac57f3aabc87405f04b86354f66799c8e62c28c5fc5f88b5521b2dbf"},
-    {file = "PyYAML-5.3-cp38-cp38-win32.whl", hash = "sha256:70024e02197337533eef7b85b068212420f950319cc8c580261963aefc75f811"},
-    {file = "PyYAML-5.3-cp38-cp38-win_amd64.whl", hash = "sha256:cb1f2f5e426dc9f07a7681419fe39cee823bb74f723f36f70399123f439e9b20"},
-    {file = "PyYAML-5.3.tar.gz", hash = "sha256:e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 pyzmq = [
     {file = "pyzmq-19.0.0-cp27-cp27m-macosx_10_9_intel.whl", hash = "sha256:3f12ce1e9cc9c31497bd82b207e8e86ccda9eebd8c9f95053aae46d15ccd2196"},
@@ -2026,8 +2028,8 @@ regex = [
     {file = "regex-2020.2.20.tar.gz", hash = "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5"},
 ]
 requests = [
-    {file = "requests-2.22.0-py2.py3-none-any.whl", hash = "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"},
-    {file = "requests-2.22.0.tar.gz", hash = "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"},
+    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
+    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
 ]
 scipy = [
     {file = "scipy-1.4.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:c5cac0c0387272ee0e789e94a570ac51deb01c796b37fb2aad1fb13f85e2f97d"},
@@ -2076,8 +2078,8 @@ structlog = [
     {file = "structlog-19.1.0.tar.gz", hash = "sha256:5feae03167620824d3ae3e8915ea8589fc28d1ad6f3edf3cc90ed7c7cb33fab5"},
 ]
 tenacity = [
-    {file = "tenacity-5.0.4-py2.py3-none-any.whl", hash = "sha256:b87c1934daa0b2ccc7db153c37b8bf91d12f165936ade8628e7b962b92dc7705"},
-    {file = "tenacity-5.0.4.tar.gz", hash = "sha256:a0c3c5f7ae0c33f5556c775ca059c12d6fd8ab7121613a713e8b7d649908571b"},
+    {file = "tenacity-5.1.5-py2.py3-none-any.whl", hash = "sha256:3a916e734559f1baa2cab965ee00061540c41db71c3bf25375b81540a19758fc"},
+    {file = "tenacity-5.1.5.tar.gz", hash = "sha256:e664bd94f088b17f46da33255ae33911ca6a0fe04b156d334b601a4ef66d3c5f"},
 ]
 terminado = [
     {file = "terminado-0.8.3-py2.py3-none-any.whl", hash = "sha256:a43dcb3e353bc680dd0783b1d9c3fc28d529f190bc54ba9a229f72fe6e7a54d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,14 @@ Click = "7.0"
 GitPython = "3.0.8"
 boltons = "19.1.0"
 dnspython = "1.16.0"
-"evergreen.py" = "1.0.2"
 fastapi = "0.45"
 misc-utils-py = "0.1.2"
 pytz = "2019.3"
 structlog = "19.1.0"
 pymongo = {version = "3.8.0", extras = ["tls"]}
 uvicorn = "^0.11.3"
+requests = "^2.24.0"
+"evergreen.py" = "^1.4.8"
 
 [tool.poetry.dev-dependencies]
 gunicorn = "^19.9.0"


### PR DESCRIPTION
I mentioned this issue in standup a few times, it used to be a TECHOPS ticket because I thought it was an issue with Kanopy, but @lviana found a fix for the issue in an updated version of the python requests library, so I am updating our python requests version.

Confirmed ConnectionResetErrors are not happening at the endpoint in staging [here](https://selected-tests.server-tig.staging.corp.mongodb.com/projects/mongodb-mongo-master/task-mappings?threshold=0&changed_files=src%2Fmongo%2Fdb%2Fexec%2Fdocument_value%2Fdocument_comparator_test.cpp%2Csrc%2Fmongo%2Fdb%2Fexec%2Fdocument_value%2Fvalue.h%2Csrc%2Fmongo%2Fdb%2Fpipeline%2Faggregation_request_test.cpp%2Csrc%2Fmongo%2Fdb%2Fpipeline%2Fdocument_source_lookup_test.cpp%2Csrc%2Fmongo%2Fdb%2Findex%2Fsort_key_generator_test.cpp%2C.evergreen.yml%2C.selected_tests.yml%2Cexpansions.yml%2Csrc%2Fmongo%2Fdb%2Fexec%2Fadd_fields_projection_executor_test.cpp%2Csrc%2Fmongo%2Fdb%2Fexec%2Fexclusion_projection_executor_test.cpp%2Csrc%2Fmongo%2Fdb%2Fpipeline%2Fdocument_source_graph_lookup_test.cpp%2Csrc%2Fmongo%2Fdb%2Fpipeline%2Fexpression_test.cpp%2Csrc%2Fmongo%2Fdb%2Fpipeline%2Fdocument_path_support_test.cpp%2Csrc%2Fmongo%2Fdb%2Fexec%2Finclusion_projection_executor_test.cpp%2Csrc%2Fmongo%2Fdb%2Fpipeline%2Fdocument_source_change_stream_test.cpp%2Cbuildscripts%2Fevergreen_generate_resmoke_tasks.py).